### PR TITLE
Use the correct JavaScript MIME type

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -423,7 +423,7 @@ var http = require('http');
 
 http.createServer(function (req, res) {
     if (req.url === '/bundle.js') {
-        res.setHeader('content-type', 'text/javascript');
+        res.setHeader('content-type', 'application/javascript');
         var b = browserify(__dirname + '/main.js').bundle();
         b.on('error', console.error);
         b.pipe(res);


### PR DESCRIPTION
`application/javascript` is the correct MIME type for JavaScript (although [browsers don’t really care](http://mathiasbynens.be/demo/javascript-mime-type)).
