### PR TITLE
remove false positives from policing-boundaries link

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -914,7 +914,7 @@ functionality all in one place under the auspices of convenience: demarcation
 turf wars and finding which modules do what.
 
 Packages that are grab-bags of features
-[waste a ton of time policing boundaries](https://github.com/jashkenas/underscore/search?q=special-case&ref=cmdform&type=Issues)
+[waste a ton of time policing boundaries](https://github.com/jashkenas/underscore/search?q=%22special-case%22&ref=cmdform&type=Issues)
 about which new features belong and don't belong.
 There is no clear natural boundary of the problem domain in this kind of package
 about what the scope is, it's all


### PR DESCRIPTION
The link [waste a ton of time policing boundaries](https://github.com/jashkenas/underscore/search?q=special-case&ref=cmdform&type=Issues) has a few false positives as evidenced by the highlighted text in the first result 
![screen shot 2014-05-26 at 4 38 11 pm](https://cloud.githubusercontent.com/assets/3216121/3085677/bb3e30b2-e517-11e3-8cf7-921fcf9b3fde.png)

Putting quotes around the search term "special-case" ([link](https://github.com/jashkenas/underscore/search?q=%22special-case%22&ref=cmdform&type=Issues)) fixes this. Currently you go from 74 matches to 63 matches so your point is still very apparent.
