### PR TITLE
Fix Browserify-HMR example

### DIFF
--- a/example/hmr/main.js
+++ b/example/hmr/main.js
@@ -1,6 +1,8 @@
-var ud = require('ud')
 function render () {
   document.body.textContent = require('./msg.js')
 }
 render()
-ud.defn(module, render)
+
+if (module.hot) {
+  module.hot.accept()
+}

--- a/readme.markdown
+++ b/readme.markdown
@@ -661,15 +661,21 @@ for more information.
 
 browserify-hmr is a plugin for doing hot module replacement (hmr).
 
-When a file changes, browserify-hmr can update the module cache so that
-`require()` will execute the new file contents without reloading the page.
+Files can mark themselves as accepting updates. If you modify a file that
+accepts updates of itself, or if you modify a dependency of a file that accepts
+updates, then the file is re-executed with the new code.
 
 For example, if we have a file, `main.js`:
 
 ``` js
-setInterval(function () {
+function render () {
   document.body.textContent = require('./msg.js')
-}, 1000)
+}
+render()
+
+if (module.hot) {
+  module.hot.accept()
+}
 ```
 
 and a file `msg.js`:
@@ -699,23 +705,6 @@ module.exports = 'wow'
 ```
 
 then a second later, the page updates to show `wow` all by itself.
-
-browserify-hmr is cautious by default when a file is updated because otherwise
-it might cause havoc with global state. When we edit `main.js`, the changes
-don't automatically appear in the page. However, if we update our `main.js` to
-use the `ud` module:
-
-``` js
-var ud = require('ud')
-function render () {
-  document.body.textContent = require('./msg.js')
-}
-render()
-ud.defn(module, render)
-```
-
-Now we no longer need to poll with `setInterval` and we can edit both `msg.js`
-and `main.js` to see changes immediately without reloading the page.
 
 ### [budo](https://github.com/mattdesl/budo)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -706,6 +706,13 @@ module.exports = 'wow'
 
 then a second later, the page updates to show `wow` all by itself.
 
+Browserify-HMR can be used with
+[react-hot-transform](https://github.com/AgentME/react-hot-transform) to
+automatically allow all React components to be updated live in addition to code
+using the `module.hot` API. Unlike
+[livereactload](https://github.com/milankinen/livereactload), only modified
+files are re-executed instead of the whole bundle on each modification.
+
 ### [budo](https://github.com/mattdesl/budo)
 
 budo is a browserify development server with a stronger focus on incremental bundling and LiveReload integration (including CSS injection). 


### PR DESCRIPTION
The current Browserify-HMR example relies on a bug in Browserify-HMR. The plugin shouldn't do anything for code that never calls `module.hot.accept` but it currently has a bug that would cause the example to work. Sorry about that!

The example using `ud.defn` works because that function calls `module.hot.accept`, but the use of `ud.defn` is superfluous because there's no need to update the pre-existing `render` function. The new execution of the module executes its own new `render` function. No reference to the older version of the `render` function is kept around. (If the `render` function was exported, then `ud.defn` would be useful in order to update the old `render` function that other modules have already imported.) I need to work on the documentation around `ud` more. I don't think it should be in brief HMR examples like here.

I also added a mention of react-hot-transform and described how it was different from livereactload immediately before it.