### PR TITLE
Exclude example should use standalone jQuery instead of jquery

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -2077,7 +2077,7 @@ the primary bundle:
 
 ```
 $ npm install jquery
-$ browserify -r jquery --standalone jquery > jquery-bundle.js
+$ browserify -r jquery --standalone jQuery > jquery-bundle.js
 ```
 
 then we want to just `require('jquery')` in a `main.js`:


### PR DESCRIPTION
The [exclude example](https://github.com/substack/browserify-handbook/tree/e21ccd34f63be30baa387fa846874602d6150c08#excluding) fails with an uncaught `TypeError: $ is not a function`.

Instead of assigning `jquery` to the global in the standalone module, it should assign `jQuery`.

The current example suggests:
```
$ browserify -r jquery --standalone jquery > jquery-bundle.js
```

Instead this should be:
```
$ browserify -r jquery --standalone jQuery > jquery-bundle.js
```

Fixes #30.

 