### PR TITLE
Fix broken "package.json" anchor link in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -57,7 +57,7 @@ front or backend alike.
   - [__dirname](#__dirname)
 - [transforms](#transforms)
   - [writing your own](#writing-your-own)
-- [package.json](#package.json)
+- [package.json](#packagejson)
   - [browser field](#browser-field)
   - [browserify.transform field](#browserifytransform-field)
 - [finding good modules](#finding-good-modules)


### PR DESCRIPTION
Clicking the package.json link in the [TOC](https://github.com/substack/browserify-handbook#table-of-contents) didn't work.

old link: https://github.com/substack/browserify-handbook#package.json
new link: https://github.com/substack/browserify-handbook#packagejson

It looks like the dot in the markdown was messing it up.